### PR TITLE
Restore volume instantaneously when it gets changed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,7 +1819,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volume-locker"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "auto-launch",
  "log",
@@ -1832,6 +1832,7 @@ dependencies = [
  "tray-icon",
  "widestring 1.2.0",
  "windows",
+ "windows-core",
  "winresource",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volume-locker"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 build = "build.rs"
 
@@ -26,10 +26,8 @@ single-instance = "0.3.3"
 log = "0.4.27"
 simplelog = "0.12.2"
 tauri-winrt-notification = "0.7.2"
-
-[dependencies.windows]
-version = "0.61"
-features = [
+windows-core = "0.61.1"
+windows = { version = "0.61.1", features = [
 	"Win32_Devices_FunctionDiscovery",
 	"Win32_Foundation",
 	"Win32_Media_Audio",
@@ -38,7 +36,7 @@ features = [
 	"Win32_System_Com_StructuredStorage",
 	"Win32_System_Variant",
 	"Win32_UI_Shell_PropertiesSystem",
-]
+] }
 
 [build-dependencies]
 winresource = "0.1.20"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Never worry about your microphone volume again!
 
 ## Demo
 
+> [!IMPORTANT]
+> This demo is outdated, since v0.6.0, Volume Locker no longer takes some seconds to restore the volume. It is now instantaneous.
+
 https://github.com/user-attachments/assets/772af810-0353-4db0-99ec-ab39c6cd6aab
 
 ## Getting Started
@@ -27,7 +30,7 @@ When you want to lock the volume of your audio output or input devices:
 
 ## Credits
 
-This is my first Rust project, with no prior experience or knowledge of the language. Don't expect the code to be pretty.
+This is my first Rust project, with no prior experience or knowledge of the language. Don't expect the code to be examplary, but I think it's overall optimised.
 
 I was dissastisfied with any existing solution because they were either relying on `nircmd.exe`, which is not open source, and also didn't allow to lock the volume of specific devices, only the current default one.
 


### PR DESCRIPTION
This took me some hours, but was worth it.

Previously, Volume Locker would scan for volumes on every 5 seconds.

Now, Volume Locker gets notified directly from Windows when some volume is changed and then restores the volume instantaneously.

While the previous approach also worked ok, this new approach makes involuntary changes of volume imperceptible.

For example, if you are live streaming, and your microphone volume gets messed during it for whatever reason, viewers could notice your microphone volume changed for some seconds. Now they won't notice anything. :)